### PR TITLE
Make abbreviation creation faster

### DIFF
--- a/src/getAbbr.js
+++ b/src/getAbbr.js
@@ -1,5 +1,6 @@
 import lowerCase from 'lodash/lowerCase'
 
+const abbreviation_rx = /([^\s])[^\s]*\s?/g
 /**
  * Get app name abbreviation, i.e.
  *   League of Legends -> lol
@@ -8,8 +9,5 @@ import lowerCase from 'lodash/lowerCase'
  * @return {String}
  */
 export default (name) => (
-  lowerCase(name)
-    .split(' ')
-    .map(word => word[0])
-    .join('')
+  lowerCase(name).replace(abbreviation_rx, '$1')
 )


### PR DESCRIPTION
This code is slower in Firefox, but constantly faster in Chromium Nightly.
This should improve situation with https://github.com/KELiON/cerebro/issues/253 a bit.

UPD: Benchmark for comparison: https://jsfiddle.net/qLcsqsvb/